### PR TITLE
refactor: makes the `id` in the `ChatCompletion` and `ChatCompletionChunk` optional

### DIFF
--- a/Sources/LLMChatOpenAI/ChatCompletion.swift
+++ b/Sources/LLMChatOpenAI/ChatCompletion.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A struct that represents a chat completion response.
 public struct ChatCompletion: Decodable, Sendable {
     /// A unique identifier for the chat completion.
-    public let id: String
+    public let id: String?
     
     /// An array of chat completion choices. Can be more than one if `n` is greater than 1.
     public let choices: [Choice]

--- a/Sources/LLMChatOpenAI/ChatCompletionChunk.swift
+++ b/Sources/LLMChatOpenAI/ChatCompletionChunk.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A struct that represents a streamed chunk of a chat completion response.
 public struct ChatCompletionChunk: Decodable, Sendable {
     /// A unique identifier for the chat completion. Each chunk has the same identifier.
-    public let id: String
+    public let id: String?
     
     /// An array of chat completion choices. Can contain more than one elements if `n` is greater than 1.
     public var choices: [Choice]


### PR DESCRIPTION
Some providers, like Google, don’t include the `id` in the chat completion response.